### PR TITLE
Fix memory usage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -215,14 +215,14 @@
 			<version>2.1</version>
 		</dependency>
 	</dependencies>
-<!--
+
+
 	<build>
 		<plugins>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-shade-plugin</artifactId>
 				<version>3.4.1</version>
-				<artifactId>maven-assembly-plugin</artifactId>
 				<configuration>
 					<appendAssemblyId>false</appendAssemblyId>
 					<archive>
@@ -230,21 +230,23 @@
 							<mainClass>com.ds4h.imagej.Image_Alignment</mainClass>
 						</manifest>
 					</archive>
+				<!--
 					<descriptorRefs>
 						<descriptorRef>jar-with-dependencies</descriptorRef>
 					</descriptorRefs>
+				-->
 				</configuration>
+
 				<executions>
 					<execution>
-						<id>make-assembly</id>  this is used for inheritance merges
-						<phase>package</phase>  bind to the packaging phase
+						<id>make-assembly</id>
+						<phase>package</phase>
 						<goals>
-							<goal>single</goal>
+							<goal>shade</goal>
 						</goals>
 					</execution>
 				</executions>
 			</plugin>
 		</plugins>
 	</build>
--->
 </project>

--- a/src/main/java/com/ds4h/model/util/MemoryController.java
+++ b/src/main/java/com/ds4h/model/util/MemoryController.java
@@ -3,6 +3,8 @@ package com.ds4h.model.util;
 import com.ds4h.model.imagePoints.ImagePoints;
 import com.sun.management.OperatingSystemMXBean;
 import ij.IJ;
+import ij.ImagePlus;
+
 import java.lang.management.ManagementFactory;
 import java.util.List;
 
@@ -11,7 +13,7 @@ import java.util.List;
  */
 public class MemoryController {
 
-    private final static double MEMORY_PERCENTAGE_LIMIT = 0.30;
+    private final static double MEMORY_PERCENTAGE_LIMIT = 30.0;
 
     private MemoryController(){
 
@@ -25,18 +27,12 @@ public class MemoryController {
     public static void controlMemory(final List<ImagePoints> imagePoints) throws OutOfMemoryError{
         long memorySize = 0;
         final long totalMemory = (IJ.maxMemory()/(1024*1024));
-        for(final ImagePoints img : imagePoints){
-            final int width = img.getWidth();
-            final int height = img.getHeight();
-            final int depth = img.getBitDepth();
-            memorySize += (((long) width *height*depth)/8);
-        }
-        memorySize = memorySize/(1024*1024);
-        IJ.log("[MEMORY SIZE IMAGE] TotalSize: " + memorySize);
-        IJ.log("[MEMORY SIZE IMAGE] Total Memory: " + totalMemory);
-        IJ.log("[MEMORY SIZE IMAGE] Percentage: " + (memorySize/(double)totalMemory));
-
-        if(memorySize/(double)totalMemory >= MEMORY_PERCENTAGE_LIMIT){
+        final long currentMemory = (IJ.currentMemory() / (1024 * 1024));
+        final double usedMemory = ((double) currentMemory / totalMemory) * 100;
+        IJ.log("[MEMORY SIZE IMAGE] TotalSize: " + currentMemory + " MB");
+        IJ.log("[MEMORY SIZE IMAGE] Total Memory: " + totalMemory + " MB");
+        IJ.log("[MEMORY SIZE IMAGE] Percentage: " + usedMemory + " %");
+        if(usedMemory >= MEMORY_PERCENTAGE_LIMIT){
             throw new OutOfMemoryError(MemoryController.getError());
         }
     }


### PR DESCRIPTION
Fix the main image size calculation, now the plugin is able to get the real size of the image without doing errors. This enable to have a better check when the plugin needs to have the overall size of all the images.